### PR TITLE
Support IANA timezone names

### DIFF
--- a/packages/syncfusion_flutter_calendar/lib/src/calendar/appointment_engine/appointment_helper.dart
+++ b/packages/syncfusion_flutter_calendar/lib/src/calendar/appointment_engine/appointment_helper.dart
@@ -560,11 +560,6 @@ bool _isAppointmentDateWithinVisibleDateRange(
 }
 
 Location _timeZoneInfoToOlsonTimeZone(String windowsTimeZoneId) {
-  try {
-    var location = timeZoneDatabase.get(windowsTimeZoneId);
-    return location;
-  } catch (ignored) {}
-
   final Map<String, String> olsonWindowsTimes = <String, String>{};
   olsonWindowsTimes['AUS Central Standard Time'] = 'Australia/Darwin';
   olsonWindowsTimes['AUS Eastern Standard Time'] = 'Australia/Sydney';
@@ -676,7 +671,7 @@ Location _timeZoneInfoToOlsonTimeZone(String windowsTimeZoneId) {
     final String timeZone = olsonWindowsTimes[windowsTimeZoneId];
     return getLocation(timeZone);
   } else {
-    return null;
+    return timeZoneDatabase.get(windowsTimeZoneId);
   }
 }
 

--- a/packages/syncfusion_flutter_calendar/lib/src/calendar/appointment_engine/appointment_helper.dart
+++ b/packages/syncfusion_flutter_calendar/lib/src/calendar/appointment_engine/appointment_helper.dart
@@ -560,6 +560,11 @@ bool _isAppointmentDateWithinVisibleDateRange(
 }
 
 Location _timeZoneInfoToOlsonTimeZone(String windowsTimeZoneId) {
+  try {
+    var location = timeZoneDatabase.get(windowsTimeZoneId);
+    return location;
+  } catch (ignored) {}
+
   final Map<String, String> olsonWindowsTimes = <String, String>{};
   olsonWindowsTimes['AUS Central Standard Time'] = 'Australia/Darwin';
   olsonWindowsTimes['AUS Eastern Standard Time'] = 'Australia/Sydney';


### PR DESCRIPTION
Allows IANA timezone names rather than just the windowsTimeZoneId.

Related to this incident:

https://www.syncfusion.com/support/directtrac/incidents/296554?updateid=1882265

