### PR TITLE
[Fix] Translation for German

### DIFF
--- a/packages/syncfusion_localizations/lib/src/l10n/syncfusion_de.arb
+++ b/packages/syncfusion_localizations/lib/src/l10n/syncfusion_de.arb
@@ -12,7 +12,7 @@
 "pdfEnterPageNumberLabel" : "Geben Sie die Seitenzahl ein", 
 "pdfInvalidPageNumberLabel" : "Bitte geben Sie eine gültige Nummer ein", 
 "pdfPaginationDialogOkLabel" : "OK", 
-"pdfPaginationDialogCancelLabel" : "STORNIEREN", 
+"pdfPaginationDialogCancelLabel" : "ABBRECHEN", 
 "allowedViewDayLabel" : "Tag", 
 "allowedViewWeekLabel" : "Woche", 
 "allowedViewWorkWeekLabel" : "Arbeitswoche", 


### PR DESCRIPTION
The translation for "Cancel" into German is not "Stornieren" but "Abbrechen"