### PR TITLE
Add overlayColor parameter to SfOverlayShape

### DIFF
--- a/packages/syncfusion_flutter_sliders/lib/src/slider_shapes.dart
+++ b/packages/syncfusion_flutter_sliders/lib/src/slider_shapes.dart
@@ -289,7 +289,9 @@ class SfTrackShape {
 /// shapes.
 class SfThumbShape {
   /// Enables subclasses to provide constant constructors.
-  const SfThumbShape();
+  const SfThumbShape({this.thumbRadius});
+
+  final double? thumbRadius;
 
   bool _isThumbOverlap(RenderBaseSlider parentBox) {
     return parentBox.showOverlappingThumbStroke;
@@ -311,7 +313,7 @@ class SfThumbShape {
       required Animation<double> enableAnimation,
       required TextDirection textDirection,
       required SfThumb? thumb}) {
-    final double radius = getPreferredSize(themeData).width / 2;
+    final double radius = thumbRadius ?? getPreferredSize(themeData).width / 2;
     final bool isThumbStroke = themeData.thumbStrokeColor != null &&
         themeData.thumbStrokeColor != Colors.transparent &&
         themeData.thumbStrokeWidth != null &&

--- a/packages/syncfusion_flutter_sliders/lib/src/slider_shapes.dart
+++ b/packages/syncfusion_flutter_sliders/lib/src/slider_shapes.dart
@@ -496,7 +496,9 @@ class SfDividerShape {
 /// shapes.
 class SfOverlayShape {
   /// Enables subclasses to provide constant constructors.
-  const SfOverlayShape();
+  const SfOverlayShape({this.overlayColor});
+
+  final Color? overlayColor;
 
   /// Returns the size based on the values passed to it.
   Size getPreferredSize(SfSliderThemeData themeData) {
@@ -517,7 +519,7 @@ class SfOverlayShape {
 
     if (paint == null) {
       paint = Paint();
-      paint.color = themeData.overlayColor!;
+      paint.color = overlayColor ?? themeData.overlayColor!;
     }
     context.canvas.drawCircle(center, tween.evaluate(animation), paint);
   }


### PR DESCRIPTION
For a simple operation, it was necessary to derive from the "SfOverlayShape" class and fill in the relevant fields. This is so hard.
That's why I added an optional parameter to SfOverlayShape class. 
I did the same in thumb radius.