### PR TITLE
remove tooltip log/power computation

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/chart/utils/helper.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/chart/utils/helper.dart
@@ -1262,7 +1262,6 @@ String getLabelValue(dynamic value, dynamic axis, [int? showDigits]) {
   if (value.toString().split('.').length > 1) {
     final String str = value.toString();
     final List<dynamic> list = str.split('.');
-    value = axis is LogarithmicAxis ? math.pow(10, value) : value;
     value = double.parse(value.toStringAsFixed(showDigits ?? 3));
     value = (list[1] == '0' ||
             list[1] == '00' ||


### PR DESCRIPTION
Related to issue https://github.com/syncfusion/flutter-examples/issues/633

The tooltip with LogarithmicAxis does not display the correct data. I removed the faulty computation.

Here is the display with the example @Marismathan gave in the link above.

With this change, the tooltip value for 'y' is correct.

With current code:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/57812158/171206260-d037ee62-56c5-4bed-aced-33a7eaedb54e.png">

With modification:
<img width="459" alt="image" src="https://user-images.githubusercontent.com/57812158/171206173-b1dca75b-ea52-46a9-a8cc-591c122c64c7.png">
