### PR TITLE
Use column.label in SfDataGrid computeHeaderCellHeight

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
@@ -939,7 +939,7 @@ class ColumnSizer {
     return _measureCellHeight(
         column,
         grid_helper.getHeaderIndex(_dataGridStateDetails!()),
-        column.columnName,
+        column.label,
         textStyle);
   }
 


### PR DESCRIPTION
In SfDataGrid computeHeaderCellHeight should use **column.label** instead of **column.columnName** as it's the **column.label** that gets displayed in the header cells.
This pull request is related to https://github.com/syncfusion/flutter-widgets/issues/872