### PR TITLE
[syncfusion_flutter_pdfviewer] Migrate jCenter to mavenCentral

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/android/build.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Currently jcentral seems to be down 