### PR TITLE
[fixed] image cache getting cleared

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/lib/src/common/pdfviewer_plugin.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/common/pdfviewer_plugin.dart
@@ -102,7 +102,6 @@ class PdfViewerPlugin {
       bool isZoomChanged,
       int currentPageNumber,
       bool canRenderImage) async {
-    imageCache.clear();
     if (!canRenderImage) {
       _nativeImage?.cancel();
       _renderingPages?.clear();
@@ -149,7 +148,6 @@ class PdfViewerPlugin {
 
   /// Dispose the rendered pages
   Future<void> closeDocument() async {
-    imageCache.clear();
     if (_documentID != null) {
       await PdfViewerPlatform.instance.closeDocument(_documentID!);
     }

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
@@ -199,18 +199,12 @@ class PdfPageViewState extends State<PdfPageView> {
 
   @override
   void dispose() {
-    PaintingBinding.instance.imageCache.clear();
-    PaintingBinding.instance.imageCache.clearLiveImages();
     _pdfViewerThemeData = null;
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!kIsDesktop) {
-      PaintingBinding.instance.imageCache.clear();
-      PaintingBinding.instance.imageCache.clearLiveImages();
-    }
     final double pageSpacing =
         widget.pageIndex == widget.pdfViewerController.pageCount - 1
             ? 0.0

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
@@ -1050,7 +1050,6 @@ class SfPdfViewerState extends State<SfPdfViewer> with WidgetsBindingObserver {
     _extractedTextCollection.clear();
     _pdfViewerThemeData = null;
     _localizations = null;
-    imageCache.clear();
     _killTextSearchIsolate();
     _plugin.closeDocument();
     _killTextExtractionIsolate();
@@ -1107,7 +1106,6 @@ class SfPdfViewerState extends State<SfPdfViewer> with WidgetsBindingObserver {
     _pageTextExtractor.clear();
     _document?.dispose();
     _document = null;
-    imageCache.clear();
     _startPage = 0;
     _endPage = 0;
     _bufferCount = 0;


### PR DESCRIPTION
**Issue**
This package clears image cache, making `CachedNetworkImage` to reload the image again and again.

Package version: `20.3.59`

---

fixes #385 