### PR TITLE
Fix SfDataGrid scroll performance with variable row height

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/widgets/scrollview_widget.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/widgets/scrollview_widget.dart
@@ -1666,9 +1666,12 @@ class VisualContainerHelper {
     double current = bodyStart;
     int currentEnd = endIndex;
 
-    final LineSizeCollection lineSizeCollection =
-        rowHeights as LineSizeCollection;
-    lineSizeCollection.suspendUpdates();
+    // note: for large lists, it is much faster NOT to suspend updates here,
+    // so that we don't have to rebuild the entire line size for all rows
+    // when resuming updates below
+    // final LineSizeCollection lineSizeCollection =
+    //     rowHeights as LineSizeCollection;
+    // lineSizeCollection.suspendUpdates();
     for (int index = bodyStartLineIndex;
         ((current <= bodyEnd ||
                     (current <= dataGridConfiguration.viewHeight)) ||
@@ -1709,7 +1712,8 @@ class VisualContainerHelper {
       rowHeightManager.dirtyRows.clear();
     }
 
-    lineSizeCollection.resumeUpdates();
+    // Do not resume here, as we did not suspend updates above
+    // lineSizeCollection.resumeUpdates();
     scrollRows.updateScrollBar(false);
   }
 

--- a/packages/syncfusion_flutter_datagrid/lib/src/grid_common/line_size_host.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/grid_common/line_size_host.dart
@@ -653,10 +653,13 @@ class LineSizeCollection extends PaddedEditableLineSizeHostBase
   ///
   void initializeDistances() {
     if (distances != null) {
-      distances!
-        ..clear()
-        ..count = getLineCount()
-        ..defaultDistance = defaultLineSize;
+      if (distances!.count != getLineCount() ||
+          distances!.defaultDistance != defaultLineSize) {
+        distances!
+          ..clear()
+          ..count = getLineCount()
+          ..defaultDistance = defaultLineSize;
+      }
       _lineNested.forEach((int key, LineSizeCollection value) {
         int repeatSizeCount = -1;
         final List<dynamic> hiddenValue = getHidden(key, repeatSizeCount);

--- a/packages/syncfusion_flutter_datagrid/lib/src/grid_common/tree_table.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/grid_common/tree_table.dart
@@ -1077,7 +1077,7 @@ class TreeTable extends TreeTableBase {
           x.parent?.color = TreeTableNodeColor.red;
           leftRotate(x.parent, inAddMode);
           if (x.parent != null) {
-            w = x.parent!.right! as TreeTableBranchBase;
+            w = x.parent!.right;
           } else {
             return;
           }


### PR DESCRIPTION
Fixes #1058, including fixing the red/black tree implementation and avoiding rebuilding the line size information for every row on every vertical scroll event.

The first major problem was that in every vertical scroll event, the line size information for every row was being reinserted into the TreeTable storing line size information (when resumeUpdates was called). This was very slow

Even more critically, the red/black tree implementation was not rebalancing correctly, leading to a tree that always had its right branch populated and never its left. This meant that the depth of the tree was always the same size as the number of nodes in the tree, leading to worst-case performance for tree operations.

Using flutter devtools to do CPU profiling, it became clear that this was causing the UX freezes during scroll. You can see in this CPU flamegraph that substantial CPU time was spent traversing the TreeTable because its depth was 4000+. (The stack was so long that it broke the CPU flamegraph as well).

![image](https://user-images.githubusercontent.com/88254524/215679925-7a01052d-5ca9-4f40-a6bc-47c0fa41947c.png)

This PR fixes the red/black tree implementation, both inserts and deletes. The tree is now properly balanced (e.g., a list with thousands of nodes now has a depth that is between 12 and 15, instead of a depth of thousands), which means that operations on it are very fast.

This PR also avoids rebuilding the line size information for every row on every scroll event.

You can test this fix with the example application listed in #1058 by putting the following into your pubspec:
```
syncfusion_flutter_datagrid:
    git:
      url: https://github.com/klondikedragon/flutter-widgets
      path: packages/syncfusion_flutter_datagrid
      ref: fix/datagrid_scroll_performance
```

With this fix in place, even in a debug build, you can smoothly scroll in an SfDataGrid with dynamic row heights with 10,000 rows! Even a grid with 100k rows is usable even in a debug build.

This code is freely contributed to and ownership is transferred to Syncfusion Inc.