### PR TITLE
Remove minWidth from all _textPainter.layout() calls

### DIFF
--- a/packages/syncfusion_flutter_datepicker/lib/src/date_picker/date_picker.dart
+++ b/packages/syncfusion_flutter_datepicker/lib/src/date_picker/date_picker.dart
@@ -8354,7 +8354,7 @@ class _PickerHeaderPainter extends CustomPainter {
 
       double textWidth = ((currentViewIndex + 1) * width) - xPosition;
       textWidth = textWidth > 0 ? textWidth : 0;
-      _textPainter.layout(minWidth: textWidth, maxWidth: textWidth);
+      _textPainter.layout(maxWidth: textWidth);
 
       if (headerStyle.textAlign == TextAlign.center) {
         xPosition = (currentViewIndex * width) +
@@ -8590,7 +8590,7 @@ class _PickerViewHeaderPainter extends CustomPainter {
 
         _textPainter.textScaleFactor = textScaleFactor;
         _textPainter.text = dayTextSpan;
-        _textPainter.layout(minWidth: width, maxWidth: width);
+        _textPainter.layout(maxWidth: width);
         yPosition = (viewHeaderHeight - _textPainter.height) / 2;
         _textPainter.paint(
             canvas,

--- a/packages/syncfusion_flutter_datepicker/lib/src/date_picker/month_view.dart
+++ b/packages/syncfusion_flutter_datepicker/lib/src/date_picker/month_view.dart
@@ -4495,7 +4495,7 @@ void _drawMonthCellsAndSelection(PaintingContext context, Size size,
       );
 
       monthView._textPainter.text = dateText;
-      monthView._textPainter.layout(minWidth: cellWidth, maxWidth: cellWidth);
+      monthView._textPainter.layout(maxWidth: cellWidth);
       monthView._textPainter.paint(
           canvas,
           Offset(xPosition + (cellWidth / 2 - monthView._textPainter.width / 2),

--- a/packages/syncfusion_flutter_datepicker/lib/src/date_picker/year_view.dart
+++ b/packages/syncfusion_flutter_datepicker/lib/src/date_picker/year_view.dart
@@ -3088,7 +3088,7 @@ class _RangeSelectionRenderObject extends _IYearViewRenderObject {
       _todayHighlightPaint.color =
           rangeSelectionColor ?? datePickerTheme.rangeSelectionColor!;
       _textPainter.text = yearText;
-      _textPainter.layout(minWidth: cellWidth, maxWidth: cellWidth);
+      _textPainter.layout(maxWidth: cellWidth);
     } else if (isEndRange) {
       _todayHighlightPaint.color =
           endRangeSelectionColor ?? datePickerTheme.endRangeSelectionColor!;
@@ -3358,7 +3358,7 @@ class _ExtendableRangeSelectionRenderObject extends _IYearViewRenderObject {
       _todayHighlightPaint.color =
           rangeSelectionColor ?? datePickerTheme.rangeSelectionColor!;
       _textPainter.text = yearText;
-      _textPainter.layout(minWidth: cellWidth, maxWidth: cellWidth);
+      _textPainter.layout(maxWidth: cellWidth);
     } else if (isEndRange) {
       _todayHighlightPaint.color =
           endRangeSelectionColor ?? datePickerTheme.endRangeSelectionColor!;
@@ -3609,7 +3609,7 @@ class _MultiRangeSelectionRenderObject extends _IYearViewRenderObject {
       _todayHighlightPaint.color =
           rangeSelectionColor ?? datePickerTheme.rangeSelectionColor!;
       _textPainter.text = yearText;
-      _textPainter.layout(minWidth: cellWidth, maxWidth: cellWidth);
+      _textPainter.layout(maxWidth: cellWidth);
     } else if (isEndRange) {
       _todayHighlightPaint.color =
           endRangeSelectionColor ?? datePickerTheme.endRangeSelectionColor!;
@@ -3993,7 +3993,7 @@ void _drawYearCells(
       );
 
       yearView._textPainter.text = yearText;
-      yearView._textPainter.layout(minWidth: cellWidth, maxWidth: cellWidth);
+      yearView._textPainter.layout(maxWidth: cellWidth);
 
       final double highlightPadding =
           yearView.selectionRadius == -1 ? 10 : yearView.selectionRadius;


### PR DESCRIPTION
This avoids that on Flutter 3.12.0, `TextPainter.layout()` calls would always return the `cellWidth` as width, independently of the actual text. The problem was that `cellWidth` was passed for `minWidth` and `maxWidth`.

This bug is related with this commit (PR) in Flutter: https://github.com/flutter/flutter/commit/62e78bf1437a4c566849ef584b66cf7c2c5f08e4

Closes #1254