### PR TITLE
Change date locale in header of  timeline_view.dart

### DIFF
--- a/packages/syncfusion_flutter_calendar/lib/src/calendar/views/timeline_view.dart
+++ b/packages/syncfusion_flutter_calendar/lib/src/calendar/views/timeline_view.dart
@@ -1267,7 +1267,7 @@ class TimelineViewHeaderView extends CustomPainter {
 
       final String dayText = DateFormat(dayFormat, locale).format(currentDate);
       final String dateText =
-          DateFormat(timeSlotViewSettings.dateFormat).format(currentDate);
+          DateFormat(timeSlotViewSettings.dateFormat,locale).format(currentDate);
 
       final bool isBlackoutDate =
           CalendarViewHelper.isDateInDateCollection(blackoutDates, currentDate);


### PR DESCRIPTION
Previously, the dateText was formatted using the DateFormat class without any specified locale, which could lead to inconsistencies when displaying dates in different locales.

To address this issue, I modified the dateText property to use the DateFormat class with the provided locale parameter. This allows the calendar to display dates according to the specified locale, ensuring a consistent and localized user experience.