### PR TITLE
[flutter-chart] Allow series color to be trackball fill default color

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/chart/user_interaction/trackball.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/chart/user_interaction/trackball.dart
@@ -1382,7 +1382,7 @@ class TrackballRenderingDetails {
       ..style = PaintingStyle.stroke;
 
     final Paint fillPaint = Paint()
-      ..color = markerSettings.color ??
+      ..color = markerSettings.color ?? seriesRendererDetails.seriesColor ??
           (renderingDetails.chartTheme.brightness == Brightness.light
               ? Colors.white
               : Colors.black)


### PR DESCRIPTION
Default fill color for trackball is only black or white.
If user needs to specify different fill color for different series in the same chart, they cannot do so in `markerSettings`.

Feature: Allow series color to be trackball fill default color if color is not specified in `markerSettings`