### PR TITLE
upgrade gradle to 7.2.1 to fix problem with AGP 8 (flutter_pdfviewer)

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/android/build.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.syncfusion.flutter.pdfviewer'
+    }
     compileSdkVersion 31
 
     defaultConfig {

--- a/packages/syncfusion_flutter_pdfviewer/android/src/main/AndroidManifest.xml
+++ b/packages/syncfusion_flutter_pdfviewer/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.syncfusion.flutter.pdfviewer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Solve namespace error when build with Gradle versions >= 8.