### PR TITLE
fix: Check mounted before setState

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datapager/sfdatapager.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datapager/sfdatapager.dart
@@ -595,7 +595,7 @@ class SfDataPagerState extends State<SfDataPager> {
     }
     final bool canChange = await _canChangePage(index);
 
-    if (canChange) {
+    if (canChange && mounted) {
       setState(() {
         _setCurrentPageIndex(index);
         _isDirty = true;


### PR DESCRIPTION
Check the mounted getter before calling setState as some async work is done before in the _canChangePage function. 
Avoids the Error: setState() called after dispose():
