### PR TITLE
SfDataGrid feature: ability to get visible rows from DataGridController

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/sfdatagrid.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/sfdatagrid.dart
@@ -5,8 +5,10 @@ import 'package:syncfusion_flutter_core/localizations.dart';
 import 'package:syncfusion_flutter_core/theme.dart';
 
 import '../../datagrid.dart';
+import '../grid_common/enums.dart';
 import '../grid_common/line_size_host.dart';
 import '../grid_common/scroll_axis.dart';
+import '../grid_common/utility_helper.dart';
 import 'helper/datagrid_configuration.dart';
 import 'helper/datagrid_helper.dart' as grid_helper;
 import 'runtime/cell_renderers.dart';
@@ -3996,6 +3998,32 @@ class DataGridController extends DataGridSourceChangeNotifier {
   }
 
   DataGridStateDetails? _dataGridStateDetails;
+
+  Int32Span? _getVisibleRowsRange(ScrollAxisRegion region) {
+    if (_dataGridStateDetails != null) {
+      final DataGridConfiguration dataGridConfiguration =
+          _dataGridStateDetails!();
+      return dataGridConfiguration.container.scrollRows
+          .getVisibleLinesRange(region);
+    } else {
+      return null;
+    }
+  }
+
+  /// Returns the range of indexes for visible header rows.
+  /// May return a null value if the information is unknown.
+  Int32Span? get visibleHeaderRowsRange =>
+      _getVisibleRowsRange(ScrollAxisRegion.header);
+
+  /// Returns the range of indexes for visible body rows.
+  /// May return a null value if the information is unknown.
+  Int32Span? get visibleBodyRowsRange =>
+      _getVisibleRowsRange(ScrollAxisRegion.body);
+
+  /// Returns the range of indexes for visible footer rows.
+  /// May return a null value if the information is unknown.
+  Int32Span? get visibleFooterRowsRange =>
+      _getVisibleRowsRange(ScrollAxisRegion.footer);
 
   /// The collection of objects that contains object of corresponding
   /// to the selected rows in [SfDataGrid].


### PR DESCRIPTION
For complex data grids where rows can have variable heights, it's not obvious to translate the current vertical offset into which rows are currently visible.

Internally, SfDataGrid already efficiently calculates this information, but it does not expose this information in any way to the user of the widget.

This PR adds the ability to retrieve visible row information through the grid controller.

This implements the feature request [here](https://www.syncfusion.com/feedback/44216/support-to-get-the-visible-rows-in-the-view), and I've confirmed that it works for the use case described in a [forum post](https://www.syncfusion.com/forums/182575/how-to-determine-currently-visible-rows).

With this modification, it's now easy to add a listener to the verticalScrollController and get visible row information whenever the vertical scroll position changes:

```dart
    verticalScrollController.addListener(() {
      // NOTE: we use a post-frame callback to ensure we get accurate info after all layout info has been calculated
      WidgetsBinding.instance.addPostFrameCallback((_) {
        if (context.mounted) {
          // NOTE: controller is a DataGridController in this widget's state
          final range = controller.visibleBodyRowsRange;
          print("DEBUG: VISIBLE ROWS RANGE: ${range?.start} - ${range?.end}");
        }
      });
    });
```