### PR TITLE
Fix crash error on ios!

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/ios/Classes/SwiftSyncfusionFlutterPdfViewerPlugin.swift
+++ b/packages/syncfusion_flutter_pdfviewer/ios/Classes/SwiftSyncfusionFlutterPdfViewerPlugin.swift
@@ -125,8 +125,11 @@ public class SwiftSyncfusionFlutterPdfViewerPlugin: NSObject, FlutterPlugin {
 
     private func getImageForPlugin(index: Int,scale: CGFloat,documentID: String) -> FlutterStandardTypedData
     {
-        let document = self.documentRepo[documentID]!!
-        let page = document.page(at: Int(index))
+        let document = self.documentRepo[documentID]
+        if(document == nil || document! == nil){
+          return nil
+        }
+        let page = document!!.page(at: Int(index))
         var pageRect = page!.getBoxRect(.mediaBox)
         let imageRect = CGRect(x: 0,y: 0,width: pageRect.size.width*CGFloat(scale),height: pageRect.size.height*CGFloat(scale))
         if #available(iOS 10.0, *) {


### PR DESCRIPTION
I have an app that uses this package, last month I received some Crash Feedback on testFlight. And I successfully repaired that. I saw a pull request that fixed these issues but it wasn't accepted. Even so, I still created this pull request ^^. Simply, a null check will cause the app to crash when an unfortunate null case appears. I don't care if the macos version has errors because I only use this package for Android and iOS versions.