### PR TITLE
Swallowed IllegalStateException when calling closeDocument

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/android/src/main/java/com/syncfusion/flutter/pdfviewer/SyncfusionFlutterPdfViewerPlugin.java
+++ b/packages/syncfusion_flutter_pdfviewer/android/src/main/java/com/syncfusion/flutter/pdfviewer/SyncfusionFlutterPdfViewerPlugin.java
@@ -231,6 +231,8 @@ public class SyncfusionFlutterPdfViewerPlugin implements FlutterPlugin, MethodCa
       documentRepo.remove(documentID);
     } catch (IOException e) {
       e.printStackTrace();
+    } catch (IllegalStateException e) {
+      e.printStackTrace();
     }
     return true;
   }

--- a/packages/syncfusion_flutter_pdfviewer/example/ios/Flutter/Debug.xcconfig
+++ b/packages/syncfusion_flutter_pdfviewer/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/syncfusion_flutter_pdfviewer/example/ios/Flutter/Release.xcconfig
+++ b/packages/syncfusion_flutter_pdfviewer/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/syncfusion_flutter_pdfviewer/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/syncfusion_flutter_pdfviewer/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import device_info_plus
 import syncfusion_pdfviewer_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   SyncfusionFlutterPdfViewerPlugin.register(with: registry.registrar(forPlugin: "SyncfusionFlutterPdfViewerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }


### PR DESCRIPTION
On Android, `PdfRenderer.close()` can throw an IllegalStateException in addition to an IOException. And IOException is swallowed by the plugin but not IllegalStateException, which can lead to app crashes when switching PDF documents inside of SfPdfViewer very quickly (hard to replicate). This solution is simply to swallow this exception too.