### PR TITLE
Swallowed IllegalStateException that can be thrown 

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/android/src/main/java/com/syncfusion/flutter/pdfviewer/SyncfusionFlutterPdfViewerPlugin.java
+++ b/packages/syncfusion_flutter_pdfviewer/android/src/main/java/com/syncfusion/flutter/pdfviewer/SyncfusionFlutterPdfViewerPlugin.java
@@ -231,6 +231,8 @@ public class SyncfusionFlutterPdfViewerPlugin implements FlutterPlugin, MethodCa
       documentRepo.remove(documentID);
     } catch (IOException e) {
       e.printStackTrace();
+    } catch (IllegalStateException e) {
+      e.printStackTrace();
     }
     return true;
   }


### PR DESCRIPTION
When calling android.graphics.pdf.PdfRenderer.close() when switching from one PDF document to another one quickly.

This bug is hard to replicate because it apparently involves a race condition when switching the PDF document of a SfPdfViewer very quickly, which means the former PDF document renderer was not closed yet when the new one is opened.

The Android plugin calls `android.graphics.pdf.PdfRenderer.close()`, which itself calls `throwIfPageOpened()` [here](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/graphics/java/android/graphics/pdf/PdfRenderer.java#189), which can throw an IllegalStateException. And since this exception is not caught by the plugin, it could crash the application and I've seen it pop up randomly in my users' logs. 

Swallowing this exception is similar to swallowing the IOException, which is already done in the same place in the code.