### PR TITLE
Expose bounds on the PdfFormField class for the PdfViewer

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/lib/src/form_fields/pdf_form_field.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/form_fields/pdf_form_field.dart
@@ -23,6 +23,11 @@ abstract class PdfFormField {
       _helper.rebuild();
     }
   }
+
+  /// Gets the bounds of the form field.
+  Rect get bounds {
+    return _helper.bounds;
+  }
 }
 
 /// Represents the form field helper.


### PR DESCRIPTION
Exposing the bounds on the PdfFormField class. Should not affect anything, other than giving the ability to see where on the page the form fields are being rendered.