### PR TITLE
fix: use String#characters instead of substring for truncation in circular charts.

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/circular_data_label_helper.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/circular_data_label_helper.dart
@@ -154,15 +154,15 @@ String addEllipse(String text, int maxLength, String ellipse, {bool? isRtl}) {
   if (isRtl ?? false) {
     if (text.contains(ellipse)) {
       text = text.replaceAll(ellipse, '');
-      text = text.substring(1, text.length);
+      text = text.takeRange(1, text.length);
     } else {
-      text = text.substring(ellipse.length, text.length);
+      text = text.takeRange(ellipse.length, text.length);
     }
     return ellipse + text;
   } else {
     maxLength--;
     final int length = maxLength - ellipse.length;
-    final String trimText = text.substring(0, length);
+    final String trimText = text.takeRange(0, length);
     return trimText + ellipse;
   }
 }
@@ -818,6 +818,16 @@ Offset getPerpendicularDistance(Offset startPoint, CircularChartPoint point) {
   return increasedLocation;
 }
 
+extension on String {
+  /// Returns a [String] representing the substring of this [String] from the
+  /// [start] index to the [end] index using the String's [characters] rather
+  /// than its code units. This ensures that the returned [String] is a valid
+  /// string and emoji characters are not split into separate characters.
+  String takeRange(int start, int end) {
+    return characters.skip(start).take(end - start).join();
+  }
+}
+
 /// To trim the text by given width.
 String getTrimmedText(String text, num labelsExtent, TextStyle labelStyle,
     {bool? isRtl}) {
@@ -828,7 +838,7 @@ String getTrimmedText(String text, num labelsExtent, TextStyle labelStyle,
     final int textLength = text.length;
     if (isRtl ?? false) {
       for (int i = 0; i < textLength - 1; i++) {
-        label = '...${text.substring(i + 1, textLength)}';
+        label = '...${text.takeRange(i + 1, textLength)}';
         size = measureText(label, labelStyle).width;
         if (size <= labelsExtent) {
           return label == '...' ? '' : label;
@@ -836,7 +846,7 @@ String getTrimmedText(String text, num labelsExtent, TextStyle labelStyle,
       }
     } else {
       for (int i = textLength - 1; i >= 0; --i) {
-        label = '${text.substring(0, i)}...';
+        label = '${text.takeRange(0, i)}...';
         size = measureText(label, labelStyle).width;
         if (size <= labelsExtent) {
           return label == '...' ? '' : label;


### PR DESCRIPTION
This PR is just being used to demonstrate that we can fix the below mentioned issue by using `package:characters` (which is exported via the Flutter SDK). Currently, the `circular_data_label_helper` uses `substring` when truncating text which is prone to causing issues if the input `String` contains, for instance, emojis like 🍕 that are comprised of multiple code points. This is explained in more detail in [this comment](https://github.com/flutter/flutter/issues/142037#issuecomment-1910613610).

**Notes:**
- This PR is not holistic in that it does not target all other uses of `.substring`, of which there seem to be 9. I just opened this to demonstrate how #1611 should likely be fixed.
- I've pushed a commit to https://github.com/btrautmann/syncfusion_charts_repros that has in its pubspec.yaml the URL/ref for this changeset available for use if you want to test yourself, just comment out the hosted version and uncomment the git ref.

**Before:**
<img src="https://github.com/syncfusion/flutter-widgets/assets/8343465/acab3d9d-c896-4d2c-98ed-a6e4007b4f03" width="300" height="600" />

**After:**
<img src="https://github.com/syncfusion/flutter-widgets/assets/8343465/68836b4b-12f8-41d1-96ff-12c0c817765f" width="300" height="600" />

Fixes https://github.com/syncfusion/flutter-widgets/issues/1611.