### PR TITLE
[SFDataGrid] Allow passing nullable list of widgets via DataGridRow

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/sfdatagrid.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/sfdatagrid.dart
@@ -128,7 +128,11 @@ typedef GroupChangedCallback = void Function(DataGridGroupChangedDetails group);
 /// constructor of each [DataGridRow] object.
 class DataGridRow {
   /// Creates [DataGridRow] for the [SfDataGrid].
-  const DataGridRow({required List<DataGridCell> cells}) : _cells = cells;
+  DataGridRow({
+    required List<DataGridCell> cells,
+    List<Widget>? widgets,
+  })  : _cells = cells,
+        _widgets = widgets ?? <Widget>[];
 
   /// The data for this row.
   ///
@@ -136,10 +140,22 @@ class DataGridRow {
   /// [SfDataGrid].
   final List<DataGridCell> _cells;
 
+  /// The data for this row.
+  ///
+  /// There must be exactly as many widgets as there are columns in the
+  /// [SfDataGrid].
+  final List<Widget> _widgets;
+
   /// Returns the collection of [DataGridCell] which is created for
   /// [DataGridRow].
   List<DataGridCell> getCells() {
     return _cells;
+  }
+
+  /// Returns the list of [Widget]s which is created for
+  /// [DataGridRow].
+  List<Widget> getWidgets() {
+    return _widgets;
   }
 }
 


### PR DESCRIPTION
It is nearly imposible to create a SFDataGrid that has dynamic Widgets determined by multiple variables(local), while mantaining the filtering capability which is higly depended on `DataGridCell.values`.

```dart
  DataGridRowAdapter buildRow(DataGridRow row) {}
 ```

Passing a List of Widgets through the DataGridRow variable, increases interoperability of the SFDataGrid library when creating complex widgets.
