### PR TITLE
Removes references to Flutter v1 android embedding classes, adds entry to changelog

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/CHANGELOG.md
+++ b/packages/syncfusion_flutter_pdfviewer/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Now, the pages being rendered will have good quality at the initial zoom level. The rendering performance of pages in the viewer for large documents has also been improved for all platforms. Especially on the web and Android platforms, we have achieved approximately an 80% deduction in the rendering time for a document of 50 MB size.
 * Provided support to scroll right-to-left (RTL) horizontally in the RTL layout. This will help you accommodate languages that are read from right to left for better continuity in reading.
 * Provided support to customize the visibility of the built-in text selection menu. This can help users design their own customized text selection menu.
+* Now, the `SyncfusionFlutterPdfViewerPlugin` will not crash on compliation on flutter versions that have removed v1 android embedding.
 
 ## [25.2.6] - 05/28/2024
 

--- a/packages/syncfusion_flutter_pdfviewer/android/src/main/java/com/syncfusion/flutter/pdfviewer/SyncfusionFlutterPdfViewerPlugin.java
+++ b/packages/syncfusion_flutter_pdfviewer/android/src/main/java/com/syncfusion/flutter/pdfviewer/SyncfusionFlutterPdfViewerPlugin.java
@@ -63,21 +63,6 @@ public class SyncfusionFlutterPdfViewerPlugin implements FlutterPlugin, MethodCa
     context = flutterPluginBinding.getApplicationContext();
   }
 
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "syncfusion_flutter_pdfviewer");
-    channel.setMethodCallHandler(new SyncfusionFlutterPdfViewerPlugin());
-  }
-
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   @Override
   public void onMethodCall(@NonNull final MethodCall call, @NonNull final Result result) {

--- a/packages/syncfusion_flutter_pdfviewer/example/android/app/build.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.syncfusion.flutter.pdfviewer.example"
-        minSdkVersion 19
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/syncfusion_flutter_pdfviewer/example/android/build.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
Fixes #1949.

Tested by building the syncfusion_flutter_pdfviewer example app with the changes in https://github.com/flutter/engine/pull/52022 applied then removed code that failed to build. 

I added a changelog entry but not a pubspec version bump because I could not figure out what your policy included. 
