### PR TITLE
Fix `No element` error

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
@@ -2246,7 +2246,7 @@ class RenderCartesianAxes extends RenderBox
       if (associatedAxis != null &&
           ((associatedAxis.isVertical && axis.isVertical) ||
               (!associatedAxis.isVertical && !axis.isVertical))) {
-        return axis.isXAxis ? _yAxes.first : _xAxes.first;
+        return axis.isXAxis ? _xAxes.first : _yAxes.first;
       } else {
         return associatedAxis;
       }


### PR DESCRIPTION
See error details:
```js
    at JavaScriptObject.get$first
    at RenderCartesianAxes._associatedAxis$1
    at RenderCartesianAxes_performUpdate_closure3.call$1
    at RenderCartesianAxes.visitChildren$1
    at RenderCartesianAxes.performUpdate$0
    at RenderCartesianChartArea._base$_update$0
    at ChartAreaRenderObjectElement.mount$2
    at StatelessElement.inflateWidget$2
    at StatelessElement.updateChild$3
```

Here's the debug session that makes me think that my fix is correct:

<img width="1225" alt="Screenshot 2024-06-26 at 4 04 14 PM" src="https://github.com/syncfusion/flutter-widgets/assets/172336215/1a6a215d-e350-410b-b30e-5c2a5b1ce107">


We can see that the `axis.isXAxis` is `false` (so it's the `Y` axis) and that the `_xAxes` is an `Array(0)`, that why `_xAxes.first` throws a `No element` error