### PR TITLE
fix: pdf's background color is now loaded by _pdfViewerThemeData

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
@@ -338,7 +338,11 @@ class PdfPageViewState extends State<PdfPageView> {
       final Widget pdfPage = Container(
         height: widget.height + heightSpacing,
         width: widget.width + widthSpacing,
-        color: Colors.white,
+        color: _pdfViewerThemeData!.backgroundColor ??
+            _effectiveThemeData!.backgroundColor ??
+            (Theme.of(context).colorScheme.brightness == Brightness.light
+                ? const Color(0xFFD6D6D6)
+                : const Color(0xFF303030)),
         alignment: Alignment.topCenter,
         child: widget.scrollDirection == PdfScrollDirection.vertical
             ? Column(children: <Widget>[
@@ -764,7 +768,11 @@ class PdfPageViewState extends State<PdfPageView> {
     final Widget child = Container(
       height: widget.height + heightSpacing,
       width: widget.width + widthSpacing,
-      color: Colors.white,
+      color: _pdfViewerThemeData!.backgroundColor ??
+          _effectiveThemeData!.backgroundColor ??
+          (Theme.of(context).colorScheme.brightness == Brightness.light
+              ? const Color(0xFFD6D6D6)
+              : const Color(0xFF303030)),
       foregroundDecoration: BoxDecoration(
         border: widget.isSinglePageView
             ? Border(left: borderSide, right: borderSide)


### PR DESCRIPTION
As the title says, the background is no longer white by default but is now loaded from the theme data.