### PR TITLE
Update build.gradle jcenter() to mavenCentral() - packages/syncfusion_flutter_pdfviewer/android/build.gradle

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/android/build.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/syncfusion_flutter_pdfviewer/pubspec.yaml
+++ b/packages/syncfusion_flutter_pdfviewer/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   intl: '>=0.18.1 <0.20.0'
 
   syncfusion_pdfviewer_platform_interface:
-    path: ../syncfusion_pdfviewer_platform_interface
+    path: ../syncfusion_flutter_pdfviewer_platform_interface
 
   syncfusion_pdfviewer_web:
     path: ../syncfusion_pdfviewer_web

--- a/packages/syncfusion_pdfviewer_macos/pubspec.yaml
+++ b/packages/syncfusion_pdfviewer_macos/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   syncfusion_pdfviewer_platform_interface:
-    path: ../syncfusion_pdfviewer_platform_interface
+    path: ../syncfusion_flutter_pdfviewer_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/syncfusion_pdfviewer_web/pubspec.yaml
+++ b/packages/syncfusion_pdfviewer_web/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   js: ^0.7.1
   meta: ^1.3.0
   syncfusion_pdfviewer_platform_interface:
-    path: ../syncfusion_pdfviewer_platform_interface
+    path: ../syncfusion_flutter_pdfviewer_platform_interface
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The documentation says it is written to use mavenCentral(), but when I checked, it was still using jcenter().

and as a result, an error like the following appears.
![image](https://github.com/user-attachments/assets/25a81adf-874b-41f8-8221-fc86ab5c6e09)
