### PR TITLE
fixing an issue with a changed api to mark a render object as dirty

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
@@ -121,7 +121,11 @@ class ChartAreaRenderObjectElement extends MultiChildRenderObjectElement {
 
   void _scheduleUpdate() {
     if (!_hasUpdateScheduled && !dirty) {
-      markNeedsBuild();
+      try {
+        markNeedsBuild();
+      } catch (e) {
+        markNeedsPaint();
+      }
       _hasUpdateScheduled = true;
     }
   }
@@ -3257,7 +3261,11 @@ class RenderLoadingIndicator extends RenderProxyBox
       }
     }
     if (buildLoadMoreIndicator) {
-      markNeedsBuild();
+      try {
+        markNeedsBuild();
+      } catch (e) {
+        markNeedsPaint();
+      }
     }
   }
 

--- a/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
@@ -121,11 +121,7 @@ class ChartAreaRenderObjectElement extends MultiChildRenderObjectElement {
 
   void _scheduleUpdate() {
     if (!_hasUpdateScheduled && !dirty) {
-      try {
-        markNeedsBuild();
-      } catch (e) {
-        markNeedsPaint();
-      }
+      markNeedsBuild();
       _hasUpdateScheduled = true;
     }
   }

--- a/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/base.dart
@@ -3257,11 +3257,9 @@ class RenderLoadingIndicator extends RenderProxyBox
       }
     }
     if (buildLoadMoreIndicator) {
-      try {
-        markNeedsBuild();
-      } catch (e) {
+
         markNeedsPaint();
-      }
+      
     }
   }
 

--- a/packages/syncfusion_flutter_charts/lib/src/charts/cartesian_chart.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/cartesian_chart.dart
@@ -1364,7 +1364,12 @@ class SfCartesianChartState extends State<SfCartesianChart>
       if (renderObject != null &&
           renderObject.attached &&
           renderObject is RenderConstrainedLayoutBuilder) {
-        renderObject.markNeedsBuild();
+        try {
+          // try to use the old code
+          renderObject.markNeedsBuild();
+        } catch (e) {
+          renderObject.markNeedsPaint();
+        }
       }
     }
   }

--- a/packages/syncfusion_flutter_charts/lib/src/charts/cartesian_chart.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/cartesian_chart.dart
@@ -1364,12 +1364,7 @@ class SfCartesianChartState extends State<SfCartesianChart>
       if (renderObject != null &&
           renderObject.attached &&
           renderObject is RenderConstrainedLayoutBuilder) {
-        try {
-          // try to use the old code
-          renderObject.markNeedsBuild();
-        } catch (e) {
           renderObject.markNeedsPaint();
-        }
       }
     }
   }

--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/core_legend.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/core_legend.dart
@@ -449,12 +449,7 @@ class LegendLayoutState extends State<LegendLayout> {
       if (renderObject != null &&
           renderObject.attached &&
           renderObject is RenderConstrainedLayoutBuilder) {
-        try {
-          // try to use the old code
-          renderObject.markNeedsBuild();
-        } catch (e) {
           renderObject.markNeedsPaint();
-        }
       }
     }
   }

--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/core_legend.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/core_legend.dart
@@ -449,7 +449,12 @@ class LegendLayoutState extends State<LegendLayout> {
       if (renderObject != null &&
           renderObject.attached &&
           renderObject is RenderConstrainedLayoutBuilder) {
-        renderObject.markNeedsBuild();
+        try {
+          // try to use the old code
+          renderObject.markNeedsBuild();
+        } catch (e) {
+          renderObject.markNeedsPaint();
+        }
       }
     }
   }

--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/core_tooltip.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/core_tooltip.dart
@@ -165,7 +165,13 @@ class CoreTooltipState extends State<CoreTooltip>
       if (renderObject != null &&
           renderObject.attached &&
           renderObject is RenderConstrainedLayoutBuilder) {
-        renderObject.markNeedsBuild();
+        try {
+          // try to use the old code
+          renderObject.markNeedsBuild();
+        } catch (e) {
+          // if it fails, on (Flutter 3.24), use markNeedsPaint instead
+          renderObject.markNeedsPaint();
+        }
       }
     }
   }
@@ -175,6 +181,9 @@ class CoreTooltipState extends State<CoreTooltip>
     // (_tooltipKey.currentContext?.findRenderObject()
     //         as RenderConstrainedLayoutBuilder<BoxConstraints, RenderBox>?)
     //     ?.markNeedsBuild();
+    // What aver this dead codes does, markNeedsBuild isn't a function available
+    // on RenderObject in flutter 3.24, should be changed to markNeedsPaint or
+    // markNeedsLayout.
   }
 
   void _startShowTimer() {

--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/core_tooltip.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/core_tooltip.dart
@@ -165,13 +165,7 @@ class CoreTooltipState extends State<CoreTooltip>
       if (renderObject != null &&
           renderObject.attached &&
           renderObject is RenderConstrainedLayoutBuilder) {
-        try {
-          // try to use the old code
-          renderObject.markNeedsBuild();
-        } catch (e) {
-          // if it fails, on (Flutter 3.24), use markNeedsPaint instead
           renderObject.markNeedsPaint();
-        }
       }
     }
   }

--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/element_widget.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/element_widget.dart
@@ -110,7 +110,14 @@ class RenderChartElementLayoutBuilder<T, D> extends RenderBox
   }
 
   void refresh() {
-    markNeedsBuild();
+    try {
+      markNeedsBuild();
+    } catch (e) {
+      // try marking this widget as dirty and needs layout repaint. This should
+      // work if the object is a RenderObject. Might need something else in other
+      // cases.
+      markNeedsLayout();
+    }
     (child as RenderChartFadeTransition?)?.refresh();
   }
 

--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/element_widget.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/element_widget.dart
@@ -110,14 +110,10 @@ class RenderChartElementLayoutBuilder<T, D> extends RenderBox
   }
 
   void refresh() {
-    try {
-      markNeedsBuild();
-    } catch (e) {
       // try marking this widget as dirty and needs layout repaint. This should
       // work if the object is a RenderObject. Might need something else in other
       // cases.
       markNeedsLayout();
-    }
     (child as RenderChartFadeTransition?)?.refresh();
   }
 


### PR DESCRIPTION
Building Syncfusion Widgets with the latest Flutter version (3.24.x) leads to an error, stating that the method markNeedsBuild is not available in RenderObjects and `RenderChartElementLayoutBuilder` which holds true for Flutters own `RenderObject` class.

Other methods are available, compare: [Flutter RenderObject API](https://api.flutter.dev/flutter/rendering/RenderObject-class.html)

Using `markNeedsPaint` and `markNeedsLayout` omits the build issue and seems to work, but I wasn't able to find unittests, hence this PR is only tested "on my machine" 

Please note that there is another reference to `markNeedsBuild` in `chart/base.dart`, which might be impacted as well, or might be implemented in `MultiChildRenderObjectWidget` Please check as well.

Might fix Bug mentioned in #2008 and #2012 