### PR TITLE
fix: https://github.com/syncfusion/flutter-widgets/issues/2113

### DIFF
--- a/packages/syncfusion_flutter_pdf/lib/src/pdf/implementation/exporting/pdf_text_extractor/font_structure.dart
+++ b/packages/syncfusion_flutter_pdf/lib/src/pdf/implementation/exporting/pdf_text_extractor/font_structure.dart
@@ -1100,10 +1100,14 @@ class FontStructure {
             fontEncoding = baseFont!.name;
           }
         } else if (fontDictionary[PdfDictionaryProperties.encoding]
-            is PdfReferenceHolder) {
-          baseFontDict = (fontDictionary[PdfDictionaryProperties.encoding]!
-                  as PdfReferenceHolder)
-              .object as PdfDictionary?;
+        is PdfReferenceHolder) {
+          final ref = (fontDictionary[PdfDictionaryProperties.encoding]!
+          as PdfReferenceHolder);
+          if (ref.object is PdfDictionary) {
+            baseFontDict = ref.object as PdfDictionary?;
+          } else {
+            fontEncoding = (ref.object as PdfName).name;
+          }
         }
         if (baseFontDict != null &&
             baseFontDict.containsKey(PdfDictionaryProperties.type)) {
@@ -1602,9 +1606,11 @@ class FontStructure {
     if (fontDictionary.containsKey(PdfDictionaryProperties.encoding)) {
       if (fontDictionary[PdfDictionaryProperties.encoding]
           is PdfReferenceHolder) {
-        encodingDictionary = (fontDictionary[PdfDictionaryProperties.encoding]!
-                as PdfReferenceHolder)
-            .object as PdfDictionary?;
+        final ref = fontDictionary[PdfDictionaryProperties.encoding]
+        as PdfReferenceHolder;
+        if (ref.object is PdfDictionary) {
+          encodingDictionary = ref.object as PdfDictionary?;
+        }
       } else if (fontDictionary[PdfDictionaryProperties.encoding]
           is PdfDictionary) {
         encodingDictionary =


### PR DESCRIPTION
This PR tries to fix https://github.com/syncfusion/flutter-widgets/issues/2113.

I'm unsure about my fix; I think the root cause of the problem is why would `fontDictionary[PdfDictionaryProperties.encoding].object` be a `PdfName` and not a `PdfDictionary` as expected in the code ?