### PR TITLE
Fix: Sorting bug fixed when cell values are different types

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
@@ -2375,14 +2375,10 @@ class DataGridFilterHelper {
     }
 
     if (cellValues.isNotEmpty) {
-      final Object cellValue = cellValues.first;
-      final bool convertToString =
-          !(cellValue is num || cellValue is DateTime || cellValue is String);
-
       // Sort the items to display in the ascending order.
       cellValues.sort((Object a, Object b) {
-        final dynamic value1 = convertToString ? a.toString() : a;
-        final dynamic value2 = convertToString ? b.toString() : b;
+        final dynamic value1 = !(a is num || a is DateTime || a is String) ? a.toString() : a;
+        final dynamic value2 = !(b is num || b is DateTime || b is String) ? b.toString() : b;
 
         return value1.compareTo(value2);
       });


### PR DESCRIPTION
When cell values populated with different types of Objects, code was determining if convertToString by checking the first element in the list. But when there is different type of object for example StrongType it was failing to sort and it was throwing error on String's compareTo methdod.

Example case: 
![image](https://github.com/user-attachments/assets/5e29dcb9-6b30-45b7-ad46-be7e59866618)
