### PR TITLE
Updated trademark symbol in all license files

### DIFF
--- a/packages/syncfusion_flutter_barcodes/LICENSE
+++ b/packages/syncfusion_flutter_barcodes/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Barcodes package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Barcodes package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_barcodes/LICENSE
+++ b/packages/syncfusion_flutter_barcodes/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Barcodes package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Barcodes package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_calendar/LICENSE
+++ b/packages/syncfusion_flutter_calendar/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Calendar package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Calendar package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_calendar/LICENSE
+++ b/packages/syncfusion_flutter_calendar/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Calendar package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Calendar package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_charts/LICENSE
+++ b/packages/syncfusion_flutter_charts/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Chart package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Chart package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_charts/LICENSE
+++ b/packages/syncfusion_flutter_charts/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Chart package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Chart package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_chat/LICENSE
+++ b/packages/syncfusion_flutter_chat/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Chat package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Chat package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_chat/LICENSE
+++ b/packages/syncfusion_flutter_chat/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Chat package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Chat package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_core/LICENSE
+++ b/packages/syncfusion_flutter_core/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Core package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Core package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_core/LICENSE
+++ b/packages/syncfusion_flutter_core/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Core package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Core package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_datagrid/LICENSE
+++ b/packages/syncfusion_flutter_datagrid/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter DataGrid package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter DataGrid package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_datagrid/LICENSE
+++ b/packages/syncfusion_flutter_datagrid/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter DataGrid package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter DataGrid package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_datagrid_export/LICENSE
+++ b/packages/syncfusion_flutter_datagrid_export/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter DataGrid Export package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter DataGrid Export package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_datagrid_export/LICENSE
+++ b/packages/syncfusion_flutter_datagrid_export/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter DataGrid Export package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter DataGrid Export package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_datepicker/LICENSE
+++ b/packages/syncfusion_flutter_datepicker/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Date Picker package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Date Picker package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_datepicker/LICENSE
+++ b/packages/syncfusion_flutter_datepicker/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Date Picker package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Date Picker package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_gauges/LICENSE
+++ b/packages/syncfusion_flutter_gauges/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Gauge package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Gauge package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_gauges/LICENSE
+++ b/packages/syncfusion_flutter_gauges/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Gauge package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Gauge package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_maps/LICENSE
+++ b/packages/syncfusion_flutter_maps/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Maps package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Maps package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_maps/LICENSE
+++ b/packages/syncfusion_flutter_maps/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Maps package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Maps package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_pdf/LICENSE
+++ b/packages/syncfusion_flutter_pdf/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  

--- a/packages/syncfusion_flutter_pdf/LICENSE
+++ b/packages/syncfusion_flutter_pdf/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  

--- a/packages/syncfusion_flutter_pdfviewer/LICENSE
+++ b/packages/syncfusion_flutter_pdfviewer/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_pdfviewer/LICENSE
+++ b/packages/syncfusion_flutter_pdfviewer/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_pdfviewer_platform_interface/LICENSE
+++ b/packages/syncfusion_flutter_pdfviewer_platform_interface/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_pdfviewer_platform_interface/LICENSE
+++ b/packages/syncfusion_flutter_pdfviewer_platform_interface/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_flutter_signaturepad/LICENSE
+++ b/packages/syncfusion_flutter_signaturepad/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter SignaturePad package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter SignaturePad package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_signaturepad/LICENSE
+++ b/packages/syncfusion_flutter_signaturepad/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter SignaturePad package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter SignaturePad package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_sliders/LICENSE
+++ b/packages/syncfusion_flutter_sliders/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Sliders package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Sliders package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_sliders/LICENSE
+++ b/packages/syncfusion_flutter_sliders/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Sliders package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Sliders package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_treemap/LICENSE
+++ b/packages/syncfusion_flutter_treemap/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Treemap package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Treemap package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_treemap/LICENSE
+++ b/packages/syncfusion_flutter_treemap/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter Treemap package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter Treemap package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_flutter_xlsio/LICENSE
+++ b/packages/syncfusion_flutter_xlsio/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter XlsIO package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter XlsIO package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  

--- a/packages/syncfusion_flutter_xlsio/LICENSE
+++ b/packages/syncfusion_flutter_xlsio/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter XlsIO package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter XlsIO package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  

--- a/packages/syncfusion_localizations/LICENSE
+++ b/packages/syncfusion_localizations/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Localizations package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Localizations package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_localizations/LICENSE
+++ b/packages/syncfusion_localizations/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Localizations package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Localizations package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_officechart/LICENSE
+++ b/packages/syncfusion_officechart/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter OfficeChart package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter OfficeChart package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  

--- a/packages/syncfusion_officechart/LICENSE
+++ b/packages/syncfusion_officechart/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter OfficeChart package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter OfficeChart package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  

--- a/packages/syncfusion_officecore/LICENSE
+++ b/packages/syncfusion_officecore/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter OfficeCore package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter OfficeCore package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_officecore/LICENSE
+++ b/packages/syncfusion_officecore/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter OfficeCore package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter OfficeCore package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
 

--- a/packages/syncfusion_pdfviewer_macos/LICENSE
+++ b/packages/syncfusion_pdfviewer_macos/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_pdfviewer_macos/LICENSE
+++ b/packages/syncfusion_pdfviewer_macos/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_pdfviewer_web/LICENSE
+++ b/packages/syncfusion_pdfviewer_web/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_pdfviewer_web/LICENSE
+++ b/packages/syncfusion_pdfviewer_web/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_pdfviewer_windows/LICENSE
+++ b/packages/syncfusion_pdfviewer_windows/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 

--- a/packages/syncfusion_pdfviewer_windows/LICENSE
+++ b/packages/syncfusion_pdfviewer_windows/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Flutter PDF Viewer package is available under the Syncfusion Essential Studio&reg; program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions.
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol near to the Essential Studio word in all license files.

![image](https://github.com/user-attachments/assets/9377dd7e-d717-473a-bb8d-420164b2d4c1)


































