### PR TITLE
Fix: Ensure PdfForm is returned even when acroForm has no fields

### DIFF
--- a/packages/syncfusion_flutter_pdf/lib/src/pdf/implementation/pdf_document/pdf_document.dart
+++ b/packages/syncfusion_flutter_pdf/lib/src/pdf/implementation/pdf_document/pdf_document.dart
@@ -516,22 +516,21 @@ class PdfDocument {
                       .createFormFieldsFromWidgets(_form!.fields.count);
                 }
               }
+              return _form!;
             }
           }
-        } else {
-          _form = PdfFormHelper.internal(_helper.crossTable);
-          _helper.catalog.setProperty(
-              PdfDictionaryProperties.acroForm, PdfReferenceHolder(_form));
-          _helper.catalog.form = _form;
-          return _form!;
         }
+        _form = PdfFormHelper.internal(_helper.crossTable);
+        _helper.catalog.setProperty(
+            PdfDictionaryProperties.acroForm, PdfReferenceHolder(_form));
+        _helper.catalog.form = _form;
+        return _form!;
       } else {
         return _form!;
       }
     } else {
       return _helper.catalog.form ??= PdfForm();
     }
-    return _form!;
   }
 
   //Public methods


### PR DESCRIPTION
### Summary

This pull request fixes an issue in the `PdfDocument.form` getter where the form would not be returned if the `acroForm` existed in the catalog but contained no fields (`fields.count == 0`). 

As a result, `_form` would remain `null`, leading to inconsistent behavior or potential `null` access elsewhere in the code.

### What was changed

- Moved the return statement outside the `if (_form!.fields.count != 0)` condition.
- Ensured `_form` is always returned once initialized, regardless of the number of fields.

### Why is this needed?

In some PDF documents, the `acroForm` dictionary exists but does not yet have any form fields (e.g., newly created or partially filled forms). Without this fix, attempting to access `form` would result in a `null`, which may cause exceptions or unexpected behavior in consumer code.

### How to test

- Open a PDF document with an empty `acroForm` dictionary.
- Call `document.form` and ensure it returns a valid `PdfForm` instance, not `null`.
- Ensure no exceptions are thrown during the access.