### PR TITLE
FLUT-953870 - [Others] Removed macOS app center link flutter widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Explore the full capabilities of our Flutter widgets on your device by installin
   <a href="https://www.microsoft.com/en-us/p/syncfusion-flutter-gallery/9nhnbwcsf85d?activetab=pivot:overviewtab"><img src="https://cdn.syncfusion.com/content/images/FTControl/windows-store.png"/></a> 
 </p>
 <p align="center">
-  <a href="https://install.appcenter.ms/orgs/syncfusion-demos/apps/syncfusion-flutter-gallery/distribution_groups/release"><img src="https://cdn.syncfusion.com/content/images/FTControl/macos-app-center.png"/></a>
   <a href="https://snapcraft.io/syncfusion-flutter-gallery"><img src="https://cdn.syncfusion.com/content/images/FTControl/snap-store.png"/></a>
   <a href="https://github.com/syncfusion/flutter-examples"><img src="https://cdn.syncfusion.com/content/images/FTControl/github-samples.png"/></a>
 </p>


### PR DESCRIPTION
## Description ##

Task ID - [[FLUT-953870]](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/953870/)
Removed macOS app center link from the flutter widgets readme files.

Before Removing link:

![image](https://github.com/user-attachments/assets/a3915e19-cb69-4ccd-beb8-1d81fdd05864)

After Removing link:

![image](https://github.com/user-attachments/assets/9ffa3f22-c742-47e4-b39f-b94b1d09282c)