### PR TITLE
Flag to position labels at the beginning of each interval

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/charts/axis/datetime_axis.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/axis/datetime_axis.dart
@@ -53,6 +53,7 @@ class DateTimeAxis extends ChartAxis {
     super.labelStyle,
     this.dateFormat,
     this.intervalType = DateTimeIntervalType.auto,
+    this.labelsAtBeginning = false,
     super.interactiveTooltip,
     this.labelFormat,
     this.minimum,
@@ -110,6 +111,25 @@ class DateTimeAxis extends ChartAxis {
   /// }
   /// ```
   final String? labelFormat;
+
+  /// If true and an [intervalType] is set to a value different than `DateTimeIntervalType.auto`
+  /// the labels are positioned at the beginning of each interval, e.g., at the first of a month.
+  /// Otherwise, for `DateTimeIntervalType.years` and `DateTimeIntervalType.months` the labels are placed dynamically
+  ///
+  /// Defaults to `false`.
+  ///
+  /// Also refer [DateTimeIntervalType].
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///    return Container(
+  ///        child: SfCartesianChart(
+  ///           primaryXAxis:
+  ///             DateTimeAxis(intervalType: DateTimeIntervalType.years, labelsAtBeginning: true),
+  ///        )
+  ///    );
+  /// }
+  /// ```
+  final bool labelsAtBeginning;
 
   /// Customizes the date-time axis intervals. Intervals can be set to days,
   /// hours, milliseconds, minutes, months, seconds, years, and auto. If it is
@@ -342,6 +362,7 @@ class DateTimeAxis extends ChartAxis {
       ..dateFormat = dateFormat
       ..labelFormat = labelFormat
       ..intervalType = intervalType
+      ..labelsAtBeginning = labelsAtBeginning
       ..minimum = minimum
       ..maximum = maximum
       ..initialVisibleMinimum = initialVisibleMinimum
@@ -360,6 +381,7 @@ class DateTimeAxis extends ChartAxis {
       ..dateFormat = dateFormat
       ..labelFormat = labelFormat
       ..intervalType = intervalType
+      ..labelsAtBeginning = labelsAtBeginning
       ..minimum = minimum
       ..maximum = maximum
       ..autoScrollingDeltaType = autoScrollingDeltaType
@@ -406,6 +428,15 @@ class RenderDateTimeAxis extends RenderChartAxis {
   set intervalType(DateTimeIntervalType value) {
     if (_intervalType != value) {
       _intervalType = value;
+      markNeedsLayout();
+    }
+  }
+
+  bool get labelsAtBeginning => _labelsAtBeginning;
+  bool _labelsAtBeginning = false;
+  set labelsAtBeginning(bool value) {
+    if (_labelsAtBeginning != value) {
+      _labelsAtBeginning = value;
       markNeedsLayout();
     }
   }
@@ -1236,13 +1267,13 @@ class RenderDateTimeAxis extends RenderChartAxis {
       case DateTimeIntervalType.years:
         final int year =
             ((date.year / visibleInterval).floor() * visibleInterval).floor();
-        date = DateTime(year, date.month, date.day);
+        date = DateTime(year, labelsAtBeginning ? 1 : date.month, labelsAtBeginning ? 1 : date.day);
         break;
 
       case DateTimeIntervalType.months:
         final int month =
             ((date.month / visibleInterval) * visibleInterval).floor();
-        date = DateTime(date.year, month, date.day);
+        date = DateTime(date.year, month, labelsAtBeginning ? 1 : date.day);
         break;
 
       case DateTimeIntervalType.days:


### PR DESCRIPTION
As an alternative to the dynamic placing of labels for DateTimeIntervalType.months and DateTimeIntervalType.years, the flag labelsAtBeginning can be set to true for DateTimeAxis to force the label position to the beginning of each month or year, respectively. Lower interval types already place the labels at the beginning of the corresponding intervals, so they are not affected by the flag. Similarly, auto is not based on any interval, so there's no effect as well.

See the difference in the video:

https://github.com/user-attachments/assets/2dcb5619-6295-44bb-b182-a750e16cecf2

The upper charts show the updated behavior with the flag set while the lower charts show the legacy behavior without the flag set. The example is available here: https://github.com/DrNiels/flutter-widgets/blob/example/fixed-axis-ticks/packages/syncfusion_flutter_charts/example/lib/main.dart

I tried my best, but I'm still foreign to your personal coding practices, so feel free to remark anything and I will adjust the code accordingly.

In response to the feature request: https://www.syncfusion.com/feedback/36499/instead-of-recalculating-the-axis-labels-keep-them-stable-on-panning
And the issue: https://github.com/syncfusion/flutter-widgets/issues/2130