### PR TITLE
fix animation error after dispose

### DIFF
--- a/packages/syncfusion_flutter_sliders/lib/src/slider.dart
+++ b/packages/syncfusion_flutter_sliders/lib/src/slider.dart
@@ -2035,7 +2035,9 @@ class _RenderSlider extends RenderBaseSlider implements MouseTrackerAnnotation {
             _state.tooltipAnimationController.status ==
                 AnimationStatus.completed &&
             !shouldAlwaysShowTooltip) {
-          _state.tooltipAnimationController.reverse();
+              if (_state.mounted) {
+              _state.tooltipAnimationController.reverse();
+              }
         }
       });
     }


### PR DESCRIPTION
Steps to reproduce
- Place the slider inside a Bottom sheet or Alert Dialog 
- Move the value - so the tooltip appears
- dispose the parent container before the tooltip disappears