### PR TITLE
Fix one-sided-zoom

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/charts/axis/axis.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/axis/axis.dart
@@ -6076,10 +6076,13 @@ abstract class ChartAxisController {
       return;
     }
 
+    final DoubleRange? visibleRange = axis.visibleRange;
     final num actualMin = _actualRange!.minimum;
     final num actualMax = _actualRange!.maximum;
-    final num visibleMin = min ?? actualMin;
-    final num visibleMax = max ?? actualMax;
+    final num currentVisibleMin = visibleRange?.minimum ?? actualMin;
+    final num currentVisibleMax = visibleRange?.maximum ?? actualMax;
+    final num visibleMin = min ?? currentVisibleMin;
+    final num visibleMax = max ?? currentVisibleMax;
     zoomFactor = (visibleMax - visibleMin) / _actualRange!.delta;
     zoomPosition = (visibleMin - actualMin) / _actualRange!.delta;
 
@@ -6087,9 +6090,6 @@ abstract class ChartAxisController {
       return;
     }
 
-    final DoubleRange? visibleRange = axis.visibleRange;
-    final num currentVisibleMin = visibleRange?.minimum ?? actualMin;
-    final num currentVisibleMax = visibleRange?.maximum ?? actualMax;
     _previousZoomFactor =
         (currentVisibleMax - currentVisibleMin) / _actualRange!.delta;
     _previousZoomPosition =


### PR DESCRIPTION
Based on issue #2354, I decided to dive deeper and found the culprit. The issue happens, when adjusting the visible range of an axis via RangeController and leaving one side as is. In that case, the visible range is updated to the actual min/max for the side that should remain equal.

As far as I understood the source code: _updateZoomFactorAndPosition gets the updated min and max as input. If a value does not change, it is given as null. Based on the new values, the new zoom factor and position are determined. In the current implementation, the fallback for null, i.e., nothing should change, is the actual min/max, leading to the visible range jumping to 2000 in the example from the issue. As the zoom is based on the visible range, that should be used as fallback instead, which is what I did in this PR.

I tried my best, but I'm still foreign to your personal coding practices, so feel free to remark anything and I will adjust the code accordingly.