### PR TITLE
fix: Prevent disposed RenderObject error in chart widgets (Flutter 3.32.6+)

### DIFF
--- a/packages/syncfusion_flutter_charts/lib/src/charts/common/element_widget.dart
+++ b/packages/syncfusion_flutter_charts/lib/src/charts/common/element_widget.dart
@@ -51,6 +51,9 @@ class RenderChartFadeTransition extends RenderAnimatedOpacity {
   }
 
   void refresh() {
+    if (!attached) {
+      return;
+    }
     markNeedsLayout();
     (child as RenderChartElementStack?)?.refresh();
   }
@@ -111,6 +114,9 @@ class RenderChartElementLayoutBuilder<T, D> extends RenderBox
   }
 
   void refresh() {
+    if (!attached) {
+      return;
+    }
     markNeedsBuild();
     (child as RenderChartFadeTransition?)?.refresh();
   }
@@ -195,6 +201,9 @@ class RenderChartElementStack extends RenderBox
   ChartMarker markerAt(int pointIndex) => ChartMarker();
 
   void refresh() {
+    if (!attached) {
+      return;
+    }
     markNeedsLayout();
   }
 


### PR DESCRIPTION
This PR fixes the "A disposed RenderObject was mutated" error that occurs when disposing chart widgets in Flutter 3.32.6 and later.

- Adds guards to ensure `refresh()` and `markNeedsLayout()` are not called after the RenderObject is disposed.
- Prevents mutation of disposed RenderObjects in chart element widgets.
- Resolves navigation and disposal issues with Syncfusion charts on recent Flutter versions.

Closes: #2394 

Tested on Flutter 3.32.6 and confirmed the error no longer occurs when navigating away from a chart page.

Thank you!