### PR TITLE
Android compileSdk version changed to 36 

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/android/build.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/android/build.gradle
@@ -25,7 +25,7 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.syncfusion.flutter.pdfviewer'
     }
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/syncfusion_flutter_pdfviewer/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/syncfusion_flutter_pdfviewer/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/packages/syncfusion_flutter_pdfviewer/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/syncfusion_flutter_pdfviewer/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/packages/syncfusion_flutter_pdfviewer/example/android/settings.gradle
+++ b/packages/syncfusion_flutter_pdfviewer/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version '8.13.0' apply false
+    id "org.jetbrains.kotlin.android" version '2.2.20' apply false
 }
 
 include ":app"

--- a/packages/syncfusion_pdfviewer_android/android/build.gradle
+++ b/packages/syncfusion_pdfviewer_android/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: "com.android.library"
 android {
     namespace = "com.syncfusion.flutter.pdfviewer.android"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -32,7 +32,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
     }
 
     externalNativeBuild {


### PR DESCRIPTION
. Updated the project’s compileSdk version to 36 to support for 16KB page size devices. Without this change, builds targeting newer hardware configurations may face runtime compatibility issues.
. No functional changes in app logic.
