### PR TITLE
Added loadingBuilder support for custom PDF loading widget in SfPdfViewer

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
@@ -211,6 +211,7 @@ class PdfPageView extends StatefulWidget {
   /// Called when the user taps on the page.
   final Function(Offset, int) onTap;
 
+  /// Called to build the widget displayed while the PDF page is loading.
   final Widget Function(BuildContext context)? loadingBuilder;
 
   @override

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
@@ -247,6 +247,7 @@ class PdfPageViewState extends State<PdfPageView> {
   late Size _originalPageSize;
   double _previousImageFactor = -1.0;
   bool _isTile = false;
+  Widget Function(BuildContext context)? loadingBuilder;
 
   /// Form fields in the page
   late List<PdfFormField> _formFields;
@@ -861,25 +862,27 @@ class PdfPageViewState extends State<PdfPageView> {
       child: Center(
         child: Visibility(
           visible: isVisible,
-          child: CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation<Color>(
-              _pdfViewerThemeData!.progressBarColor ??
-                  _effectiveThemeData!.progressBarColor ??
-                  (Theme.of(context).colorScheme.primary),
-            ),
-            backgroundColor:
-                _pdfViewerThemeData!.progressBarColor != null
-                    ? _pdfViewerThemeData!.progressBarColor!.withValues(
-                      alpha: 0.2,
-                    )
-                    : _effectiveThemeData!.progressBarColor != null
-                    ? _effectiveThemeData!.progressBarColor!.withValues(
-                      alpha: 0.2,
-                    )
-                    : (Theme.of(
-                      context,
-                    ).colorScheme.primary.withValues(alpha: 0.2)),
-          ),
+          child:
+             widget.loadingBuilder?.call(context) ??
+              CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  _pdfViewerThemeData!.progressBarColor ??
+                      _effectiveThemeData!.progressBarColor ??
+                      (Theme.of(context).colorScheme.primary),
+                ),
+                backgroundColor:
+                    _pdfViewerThemeData!.progressBarColor != null
+                        ? _pdfViewerThemeData!.progressBarColor!.withValues(
+                          alpha: 0.2,
+                        )
+                        : _effectiveThemeData!.progressBarColor != null
+                        ? _effectiveThemeData!.progressBarColor!.withValues(
+                          alpha: 0.2,
+                        )
+                        : (Theme.of(
+                          context,
+                        ).colorScheme.primary.withValues(alpha: 0.2)),
+              ),
         ),
       ),
     );

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
@@ -71,9 +71,9 @@ class PdfPageView extends StatefulWidget {
     this.annotations,
     this.selectedAnnotation,
     this.onAnnotationSelectionChanged,
-    this.onStickyNoteDoubleTapped,
-    {this.loadingBuilder,}
-  ) : super(key: key);
+    this.onStickyNoteDoubleTapped, {
+    this.loadingBuilder,
+  }) : super(key: key);
 
   /// Document ID of current pdf
   final String documentID;
@@ -211,6 +211,8 @@ class PdfPageView extends StatefulWidget {
   /// Called when the user taps on the page.
   final Function(Offset, int) onTap;
 
+  final Widget Function(BuildContext context)? loadingBuilder;
+
   @override
   State<StatefulWidget> createState() {
     return PdfPageViewState();
@@ -248,7 +250,6 @@ class PdfPageViewState extends State<PdfPageView> {
   late Size _originalPageSize;
   double _previousImageFactor = -1.0;
   bool _isTile = false;
-  final Widget Function(BuildContext context)? loadingBuilder;
 
   /// Form fields in the page
   late List<PdfFormField> _formFields;

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/control/pdf_page_view.dart
@@ -72,6 +72,7 @@ class PdfPageView extends StatefulWidget {
     this.selectedAnnotation,
     this.onAnnotationSelectionChanged,
     this.onStickyNoteDoubleTapped,
+    {this.loadingBuilder,}
   ) : super(key: key);
 
   /// Document ID of current pdf
@@ -247,7 +248,7 @@ class PdfPageViewState extends State<PdfPageView> {
   late Size _originalPageSize;
   double _previousImageFactor = -1.0;
   bool _isTile = false;
-  Widget Function(BuildContext context)? loadingBuilder;
+  final Widget Function(BuildContext context)? loadingBuilder;
 
   /// Form fields in the page
   late List<PdfFormField> _formFields;
@@ -863,7 +864,7 @@ class PdfPageViewState extends State<PdfPageView> {
         child: Visibility(
           visible: isVisible,
           child:
-             widget.loadingBuilder?.call(context) ??
+              widget.loadingBuilder?.call(context) ??
               CircularProgressIndicator(
                 valueColor: AlwaysStoppedAnimation<Color>(
                   _pdfViewerThemeData!.progressBarColor ??

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
@@ -1196,6 +1196,38 @@ class SfPdfViewer extends StatefulWidget {
   /// ```
   final bool canShowTextSelectionMenu;
 
+  /// Called to build a custom widget while a PDF page is loading.
+  ///
+  /// If this property is set, the returned widget will replace the default
+  /// page loading indicator in [SfPdfViewer].
+  ///
+  /// Defaults to `null`.
+  ///
+  /// This example demonstrates how to show a custom loading widget in the [SfPdfViewer].
+  ///
+  /// ```dart
+  /// class MyAppState extends State<MyApp> {
+  ///   final GlobalKey<SfPdfViewerState> _pdfViewerKey = GlobalKey();
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return Scaffold(
+  ///       appBar: AppBar(
+  ///         title: const Text('Syncfusion Flutter PDF Viewer'),
+  ///       ),
+  ///       body: SfPdfViewer.network(
+  ///         'https://cdn.syncfusion.com/content/PDFViewer/flutter-succinctly.pdf',
+  ///         key: _pdfViewerKey,
+  ///         loadingBuilder: (context) {
+  ///           return const Center(
+  ///             child: CircularProgressIndicator(),
+  ///           );
+  ///         },
+  ///       ),
+  ///     );
+  ///   }
+  /// }
+  /// ```
   final Widget Function(BuildContext context)? loadingBuilder;
 
   @override

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
@@ -3742,6 +3742,7 @@ class SfPdfViewerState extends State<SfPdfViewer> with WidgetsBindingObserver {
                     _selectedAnnotation,
                     _onAnnotationSelectionChanged,
                     _onStickyNoteAnnotationDoubleTapped,
+                    loadingBuilder: widget.loadingBuilder,
                   );
                   final double pageSpacing =
                       index == _pdfViewerController._pageCount - 1

--- a/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
+++ b/packages/syncfusion_flutter_pdfviewer/lib/src/pdfviewer.dart
@@ -189,6 +189,7 @@ class SfPdfViewer extends StatefulWidget {
     this.canShowHyperlinkDialog = true,
     this.enableHyperlinkNavigation = true,
     this.canShowTextSelectionMenu = true,
+    this.loadingBuilder,
   }) : _source = source,
        assert(pageSpacing >= 0),
        assert(!maxZoomLevel.isNaN),
@@ -252,6 +253,7 @@ class SfPdfViewer extends StatefulWidget {
     this.maxZoomLevel = 3,
     this.interactionMode = PdfInteractionMode.selection,
     this.scrollDirection,
+    this.loadingBuilder,
     this.pageLayoutMode = PdfPageLayoutMode.continuous,
     this.currentSearchTextHighlightColor = const Color.fromARGB(
       80,
@@ -305,6 +307,7 @@ class SfPdfViewer extends StatefulWidget {
     this.canShowPageLoadingIndicator = true,
     this.canShowScrollStatus = true,
     this.onPageChanged,
+    this.loadingBuilder,
     this.enableDoubleTapZooming = true,
     this.enableTextSelection = true,
     this.onTextSelectionChanged,
@@ -375,6 +378,7 @@ class SfPdfViewer extends StatefulWidget {
     this.canShowScrollHead = true,
     this.pageSpacing = 4,
     this.controller,
+    this.loadingBuilder,
     this.undoController,
     this.onZoomLevelChanged,
     this.canShowPageLoadingIndicator = true,
@@ -453,6 +457,7 @@ class SfPdfViewer extends StatefulWidget {
     this.canShowScrollHead = true,
     this.pageSpacing = 4,
     this.controller,
+    this.loadingBuilder,
     this.undoController,
     this.onZoomLevelChanged,
     this.canShowPageLoadingIndicator = true,
@@ -1190,6 +1195,8 @@ class SfPdfViewer extends StatefulWidget {
   /// }
   /// ```
   final bool canShowTextSelectionMenu;
+
+  final Widget Function(BuildContext context)? loadingBuilder;
 
   @override
   SfPdfViewerState createState() => SfPdfViewerState();
@@ -3546,23 +3553,24 @@ class SfPdfViewerState extends State<SfPdfViewer> with WidgetsBindingObserver {
     return Stack(
       children: <Widget>[
         _getEmptyContainer(),
-        LinearProgressIndicator(
-          valueColor: AlwaysStoppedAnimation<Color>(
-            _pdfViewerThemeData!.progressBarColor ??
-                _effectiveThemeData!.progressBarColor ??
-                _themeData!.colorScheme.primary,
-          ),
-          backgroundColor:
-              _pdfViewerThemeData!.progressBarColor != null
-                  ? _pdfViewerThemeData!.progressBarColor!.withValues(
-                    alpha: 0.2,
-                  )
-                  : _effectiveThemeData!.progressBarColor != null
-                  ? _effectiveThemeData!.progressBarColor!.withValues(
-                    alpha: 0.2,
-                  )
-                  : _themeData!.colorScheme.primary.withValues(alpha: 0.2),
-        ),
+        widget.loadingBuilder?.call(context) ??
+            LinearProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(
+                _pdfViewerThemeData!.progressBarColor ??
+                    _effectiveThemeData!.progressBarColor ??
+                    _themeData!.colorScheme.primary,
+              ),
+              backgroundColor:
+                  _pdfViewerThemeData!.progressBarColor != null
+                      ? _pdfViewerThemeData!.progressBarColor!.withValues(
+                        alpha: 0.2,
+                      )
+                      : _effectiveThemeData!.progressBarColor != null
+                      ? _effectiveThemeData!.progressBarColor!.withValues(
+                        alpha: 0.2,
+                      )
+                      : _themeData!.colorScheme.primary.withValues(alpha: 0.2),
+            ),
       ],
     );
   }


### PR DESCRIPTION
This PR introduces a new `loadingBuilder` callback in PdfPageView and SfPdfViewer to allow
custom PDF loading widgets, similar to other Syncfusion components.

Called to build a custom widget while a PDF page is loading.

If this property is set, the returned widget will replace the default
page loading indicator in [SfPdfViewer].

Defaults to `null`.

This example demonstrates how to show a custom loading widget in the [SfPdfViewer].

```dart
class MyAppState extends State<MyApp> {
  final GlobalKey<SfPdfViewerState> _pdfViewerKey = GlobalKey();

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Syncfusion Flutter PDF Viewer'),
      ),
      body: SfPdfViewer.network(
        'https://cdn.syncfusion.com/content/PDFViewer/flutter-succinctly.pdf',
        key: _pdfViewerKey,
        loadingBuilder: (context) {
          return const Center(
            child: CircularProgressIndicator(),
          );
        },
      ),
    );
  }
}