### PR TITLE
feat(treemap): Add rebuildToken parameter to support data value updates

### DIFF
--- a/packages/syncfusion_flutter_treemap/lib/src/layouts.dart
+++ b/packages/syncfusion_flutter_treemap/lib/src/layouts.dart
@@ -712,10 +712,14 @@ class Treemap extends StatefulWidget {
     required this.tooltipSettings,
     required this.enableDrilldown,
     required this.breadcrumbs,
+    this.rebuildToken,
   }) : super(key: key);
 
   /// Represents the length of the given data source.
   final int dataCount;
+
+  /// Optional token to force widget rebuild when data values change.
+  final Object? rebuildToken;
 
   /// Returns a value based on which index passed through it.
   final IndexedDoubleValueMapper weightValueMapper;
@@ -1194,7 +1198,8 @@ class _TreemapState extends State<Treemap> with SingleTickerProviderStateMixin {
     if (_levelsLength != widget.levels.length) {
       _levelsLength = widget.levels.length;
       _invalidate();
-    } else if (widget.dataCount != oldWidget.dataCount) {
+    } else if (widget.dataCount != oldWidget.dataCount ||
+        widget.rebuildToken != oldWidget.rebuildToken) {
       _invalidate();
     }
 

--- a/packages/syncfusion_flutter_treemap/lib/treemap.dart
+++ b/packages/syncfusion_flutter_treemap/lib/treemap.dart
@@ -1870,6 +1870,7 @@ class SfTreemap extends StatelessWidget {
     this.tooltipSettings = const TreemapTooltipSettings(),
     this.enableDrilldown = false,
     this.breadcrumbs,
+    this.rebuildToken,
   }) : assert(dataCount > 0),
        assert(levels.length > 0),
        assert(colorMappers == null || colorMappers.length > 0),
@@ -1991,6 +1992,7 @@ class SfTreemap extends StatelessWidget {
     this.tileHoverBorder,
     this.enableDrilldown = false,
     this.breadcrumbs,
+    this.rebuildToken,
   }) : assert(dataCount > 0),
        assert(levels.length > 0),
        assert(colorMappers == null || colorMappers.length > 0),
@@ -2111,6 +2113,7 @@ class SfTreemap extends StatelessWidget {
     this.tileHoverBorder,
     this.enableDrilldown = false,
     this.breadcrumbs,
+    this.rebuildToken,
   }) : assert(dataCount > 0),
        assert(levels.length > 0),
        assert(colorMappers == null || colorMappers.length > 0),
@@ -2176,6 +2179,33 @@ class SfTreemap extends StatelessWidget {
   /// See also:
   /// * [SfTreemap], to know how treemap render the tiles.
   final int dataCount;
+
+  /// Optional token to force widget rebuild when data values change.
+  ///
+  /// The treemap widget only rebuilds when [dataCount] changes. If data values
+  /// change but the count remains the same, use this parameter to trigger a
+  /// rebuild by changing its value.
+  ///
+  /// Example:
+  /// ```dart
+  /// int _rebuildToken = 0;
+  ///
+  /// void updateData() {
+  ///   setState(() {
+  ///     _data = newData;
+  ///     _rebuildToken++;
+  ///   });
+  /// }
+  ///
+  /// SfTreemap(
+  ///   dataCount: _data.length,
+  ///   rebuildToken: _rebuildToken,
+  /// )
+  /// ```
+  ///
+  /// See also:
+  /// * [SfTreemap.dataCount], to know how to set the data count.
+  final Object? rebuildToken;
 
   /// Returns the values which determines the weight of each tile.
   ///
@@ -3085,6 +3115,7 @@ class SfTreemap extends StatelessWidget {
       tooltipSettings: tooltipSettings,
       enableDrilldown: enableDrilldown,
       breadcrumbs: breadcrumbs,
+      rebuildToken: rebuildToken,
     );
   }
 


### PR DESCRIPTION
## Problem

  `SfTreemap` doesn't update when data values change if `dataCount` stays the same. 

FR: https://www.syncfusion.com/feedback/47083/provide-dynamic-update-support-for-treemap-datasource-without-changing-the-data

  ## Previous Workaround

  The only way to force a rebuild was using a `Key`:

  ```dart
  SfTreemap(
    key: ValueKey(Object.hashAll(data.map((e) => e.hashCode))),
    dataCount: data.length,
    // ...
  )

  Downsides:
  - Forces complete widget rebuild (loses state, animations)
  - Not intuitive - key is meant for widget identity, not data changes

  Solution

  Added optional rebuildToken parameter. When this value changes, the widget rebuilds
  even if dataCount is unchanged.

  SfTreemap(
    dataCount: data.length,
    rebuildToken: Object.hashAll(data.map((e) => e.hashCode)),
    // ...
  )

  Or simply use an int counter:

  int _rebuildCounter = 0;

  // When data changes:
  setState(() {
    _rebuildCounter++;
  });

  SfTreemap(
    dataCount: data.length,
    rebuildToken: _rebuildCounter,
    // ...
  )

  Advantages:
  - Clean, declarative API
  - Explicit intent - clearly indicates "rebuild when data changes"
  - No breaking changes - parameter is optional with default null
  ```
 ## Demo

  Before (no update):

  https://github.com/user-attachments/assets/9de70af2-3fe1-420f-ab96-6e7e9a217f77

  After (with rebuildToken):

  https://github.com/user-attachments/assets/176c92b1-97e5-4649-9a37-907f8653af0c


  Fixes #1396
  