### PR TITLE
Fix: [syncfusion_flutter_gauges] SfLinearGauge drag offset issue inside custom RenderObjects with Paint Offset

### DIFF
--- a/packages/syncfusion_flutter_gauges/lib/src/linear_gauge/gauge/linear_gauge_render_widget.dart
+++ b/packages/syncfusion_flutter_gauges/lib/src/linear_gauge/gauge/linear_gauge_render_widget.dart
@@ -1042,7 +1042,8 @@ class RenderLinearGauge extends RenderBox
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    final double currentValue = _getValueFromPosition(details.localPosition);
+    final Offset localPos = globalToLocal(details.globalPosition);
+    final double currentValue = _getValueFromPosition(localPos);
     if (_markerRenderObject.onChanged != null &&
         _markerRenderObject.value != currentValue) {
       _markerRenderObject.oldValue = currentValue;


### PR DESCRIPTION
Hello,

Here is a pull request related to [issue](https://github.com/syncfusion/flutter-widgets/issues/2486).

This is the patch explained in the issue and currently being used in one of our apps with @scalz.

Thank you in advance, 
Thibaut