### PR TITLE
Add additional check to avoid cast issues in PdfNumber when accessing bookmarks

### DIFF
--- a/packages/syncfusion_flutter_pdf/lib/src/pdf/implementation/general/pdf_named_destination.dart
+++ b/packages/syncfusion_flutter_pdf/lib/src/pdf/implementation/general/pdf_named_destination.dart
@@ -135,8 +135,8 @@ class PdfNamedDestination implements IPdfWrapper {
               _destination!.mode = PdfDestinationMode.fitH;
             }
           } else if (mode.name == 'XYZ' && destination.count > 3) {
-            final PdfNumber? left = destination[2] as PdfNumber?;
-            final PdfNumber? top = destination[3] as PdfNumber?;
+            final PdfNumber? left = (destination[2] is PdfNumber) ? destination[2] as PdfNumber : null;
+            final PdfNumber? top = (destination[3] is PdfNumber) ? destination[3] as PdfNumber : null;
             PdfNumber? zoom;
             if (destination.count > 4 && destination[4] is PdfNumber) {
               zoom = destination[4]! as PdfNumber;


### PR DESCRIPTION
Hi everyone,
I ran into the following runtime error when accessing a bookmark destination (from a namedDestination):
> type 'PdfNull' is not a subtype of type 'PdfNumber?' in type cast

Unfortunately I cann't share the original PDF (probably malformed), but it opens correctly on other viewers.

This PR fixes the issue by adding a simple defensive type check before casting the destination value to PdfNumber, preventing invalid casts when the destination contains PdfNull (or anything else)
