### PR TITLE
[pdfviewer] Allow device_info_plus ^13.0.0

### DIFF
--- a/packages/syncfusion_flutter_pdfviewer/pubspec.yaml
+++ b/packages/syncfusion_flutter_pdfviewer/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   vector_math: ^2.2.0
   url_launcher: ^6.1.0
   intl: '>=0.18.1 <0.21.0'
-  device_info_plus: ^12.1.0
+  device_info_plus: ^13.1.0
   syncfusion_pdfviewer_platform_interface:
     path: ../syncfusion_flutter_pdfviewer_platform_interface
 


### PR DESCRIPTION
Fixes #2526.

### What

Bumps the `device_info_plus` constraint in `syncfusion_flutter_pdfviewer` from `^12.1.0` to `^13.1.0`, so downstream apps that depend on `device_info_plus ^13.0.0` can use this package without forking.

### Why

`device_info_plus 13.0.0` was a platform min-SDK bump on Android/iOS; the Dart API surface used by `pdfviewer` is unchanged. The only API removal in v13 (`IosDeviceInfo.utsname`) is not used here.

### API surface used by pdfviewer

From `lib/src/pdfviewer.dart`:
- `DeviceInfoPlugin()`
- `.androidInfo`, `.webBrowserInfo`
- `AndroidDeviceInfo.version.sdkInt`
- `AndroidDeviceInfo.systemFeatures`
- `WebBrowserInfo.maxTouchPoints`

All of these are stable across v12 and v13.

### Verification

- `flutter pub get` — resolves `device_info_plus 13.1.0` cleanly
- `flutter analyze` — no issues (package and `example/`)
- No source changes required

### Diff

```yaml
# packages/syncfusion_flutter_pdfviewer/pubspec.yaml
-  device_info_plus: ^12.1.0
+  device_info_plus: ^13.1.0
```