### PR TITLE
Support server-side pagination in SfDataGrid column filters

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/datagrid.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/datagrid.dart
@@ -41,7 +41,7 @@ export './src/grid_common/row_column_index.dart';
 export 'src/datagrid_widget/helper/callbackargs.dart'
     hide setColumnSizerInRowHeightDetailsArgs;
 export 'src/datagrid_widget/helper/enums.dart'
-    hide FilteredFrom, AdvancedFilterType;
+    hide FilteredFrom;
 export 'src/datagrid_widget/runtime/column.dart'
     hide
         ColumnResizeController,

--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
@@ -2271,6 +2271,30 @@ class FilterCondition {
   }
 }
 
+/// A mixin that allows a [DataGridSource] to supply static values for the
+/// checkbox filter popup, rather than deriving them from the currently-loaded
+/// rows.
+///
+/// This is useful for server-side [SfDataGrid]s where only one page of data is
+/// loaded at a time, and the checkbox filter would otherwise show only the
+/// values present in the current page.
+///
+/// ```dart
+/// class MyDataSource extends DataGridSource with CheckboxFilterValueProvider {
+///   @override
+///   List<Object>? getCheckboxFilterValues(String columnName) {
+///     if (columnName == 'status') return <Object>['Active', 'Inactive'];
+///     return null; // fall back to default row-derived values
+///   }
+/// }
+/// ```
+mixin CheckboxFilterValueProvider {
+  /// Return the list of values to display in the checkbox filter popup for
+  /// [columnName], or `null` to fall back to the default behaviour of
+  /// deriving values from the currently-loaded rows.
+  List<Object>? getCheckboxFilterValues(String columnName);
+}
+
 /// Provides the base functionalities to process the filtering in [SfDataGrid].
 class DataGridFilterHelper {
   /// Creates the [DataGridFilterHelper] for [SfDataGrid].
@@ -2533,7 +2557,8 @@ class DataGridFilterHelper {
                       condition.type == FilterType.lessThanOrEqual)) {
                 return true;
               } else {
-                if (cellValue?.runtimeType != condition.value?.runtimeType &&
+                if (condition.value != null &&
+                    cellValue?.runtimeType != condition.value?.runtimeType &&
                     (cellValue is! num && condition.value is! num)) {
                   throwAssertFailure(
                     '${condition.value?.runtimeType} and ${cellValue.runtimeType} are not the same data type',
@@ -2745,10 +2770,22 @@ class DataGridFilterHelper {
   /// Sets all the cell values to the check box filter.
   void setDataGridSource(GridColumn column) {
     final List<DataGridRow> items = _getPreviousFilteredRows(column.columnName);
-    final List<FilterElement> distinctCollection = _getCellValues(
-      column,
-      items,
-    );
+    final DataGridSource source = _dataGridStateDetails().source;
+    List<FilterElement> distinctCollection;
+
+    if (source is CheckboxFilterValueProvider) {
+      final List<Object>? customValues =
+          (source as CheckboxFilterValueProvider)
+              .getCheckboxFilterValues(column.columnName);
+      if (customValues != null) {
+        distinctCollection =
+            _getCustomFilterElements(column, customValues, source);
+      } else {
+        distinctCollection = _getCellValues(column, items);
+      }
+    } else {
+      distinctCollection = _getCellValues(column, items);
+    }
 
     checkboxFilterHelper._previousDataGridSource = <FilterElement>[];
 
@@ -2773,6 +2810,41 @@ class DataGridFilterHelper {
     }
 
     checkboxFilterHelper.ensureSelectAllCheckboxState();
+  }
+
+  /// Builds [FilterElement]s from a static [customValues] list.
+  ///
+  /// Uses the same selection-state logic as [_getCellValues]: all values are
+  /// selected when no filter is active; when a filter is active, a value is
+  /// selected if it appears in the current [DataGridSource.effectiveRows].
+  List<FilterElement> _getCustomFilterElements(
+    GridColumn column,
+    List<Object> customValues,
+    DataGridSource source,
+  ) {
+    final List<FilterCondition> conditions =
+        source.filterConditions[column.columnName] ?? <FilterCondition>[];
+
+    bool isSelected(Object value) {
+      if (conditions.isNotEmpty) {
+        for (final DataGridRow row in source.effectiveRows) {
+          final DataGridCell? cell = row.getCells().firstWhereOrNull(
+            (DataGridCell element) => element.columnName == column.columnName,
+          );
+          if (cell?.value?.toString() == value.toString()) {
+            return true;
+          }
+        }
+        return false;
+      }
+      return true;
+    }
+
+    return customValues
+        .map<FilterElement>(
+          (Object v) => FilterElement(value: v, isSelected: isSelected(v)),
+        )
+        .toList();
   }
 
   List<DataGridRow> _getFilterRows(
@@ -3261,6 +3333,8 @@ class DataGridAdvancedFilterHelper {
     ];
 
     textFieldFilterTypes = <String>[
+      localizations.equalsDataGridFilteringLabel,
+      localizations.doesNotEqualDataGridFilteringLabel,
       localizations.beginsWithDataGridFilteringLabel,
       localizations.endsWithDataGridFilteringLabel,
       localizations.doesNotBeginWithDataGridFilteringLabel,
@@ -3331,6 +3405,15 @@ class DataGridAdvancedFilterHelper {
     DataGridConfiguration dataGridConfiguration,
     GridColumn column,
   ) {
+    // If the column explicitly declares its advanced filter type (e.g. for
+    // server-side grids where source.rows may be empty), honour that directly.
+    final AdvancedFilterType? explicit =
+        column.filterPopupMenuOptions?.advancedFilterType;
+    if (explicit != null) {
+      advancedFilterType = explicit;
+      return;
+    }
+
     Object? value;
     for (final DataGridRow row in dataGridConfiguration.source.rows) {
       final DataGridCell? cellValue = row.getCells().firstWhereOrNull(
@@ -3435,6 +3518,7 @@ class FilterPopupMenuOptions {
     this.canShowClearFilterOption = true,
     this.canShowSortingOptions = true,
     this.showColumnName = true,
+    this.advancedFilterType,
   });
 
   /// Decides how the checked listbox and advanced filter options should be shown in filter popup.
@@ -3448,6 +3532,11 @@ class FilterPopupMenuOptions {
 
   /// Decides whether the column name should be displayed along with the content of `Clear Filter` option .
   final bool showColumnName;
+
+  /// Explicitly sets the advanced filter type for the column, bypassing the
+  /// automatic detection from [DataGridSource.rows]. Use this for server-side
+  /// grids where rows may be empty or partial when the filter dialog opens.
+  final AdvancedFilterType? advancedFilterType;
 }
 
 /// Process column resizing operation in [SfDataGrid].


### PR DESCRIPTION
## Summary

This PR contains several related improvements so `SfDataGrid`'s built-in filters work correctly in **server-side pagination** scenarios, where `DataGridSource.rows` only holds one page of data at a time:

1. **`CheckboxFilterValueProvider` mixin** — A `DataGridSource` can opt into this mixin to supply a static list of values for the checkbox filter popup per column, instead of the default row-derived list.
2. **Equals/DoesNotEqual use text input** — Adds `equals` and `doesNotEqual` to `textFieldFilterTypes` in `DataGridAdvancedFilterHelper`, enabling free-text input for these filter types in the advanced filter popup.
3. **`advancedFilterType` on `FilterPopupMenuOptions`** — Exposes a new `advancedFilterType` field so callers can override the filter mode (`text`, `numeric`, `date`) per column without relying on cell-value inference.
4. **`AdvancedFilterType` exported from public API** — Re-exports `AdvancedFilterType` from the package's public barrel so consumers can reference the enum without reaching into internal paths.
5. **Fix null-value type-check crash** — Guards `_debugCheckDataType` so that filter conditions with a `null` value (i.e. "Is Null" / "Is Not Null" filter types) no longer throw a `FlutterError` when rows are refreshed or a column is sorted.

## Motivation

When using server-side pagination, `DataGridSource.rows` only contains one page of data at a time. This causes multiple problems with the built-in filter UI:

**Checkbox filter:**
`CheckboxFilterView` derives its unique values from `DataGridSource.rows`, so values from other pages disappear from the filter list on navigation, making the checkbox filter unusable for server-side grids. The `CheckboxFilterValueProvider` mixin lets the source provide the full value set explicitly.

**Advanced filter (equals/doesNotEqual):**
`equals` and `doesNotEqual` were only driven by a dropdown populated from the current page's rows. Values from other pages are not available, making exact-match filtering impractical. Users who know the exact value they want should be able to type it directly instead of selecting from an incomplete list.

**Advanced filter (column type inference):**
For server-side grids, cell values may be stored as strings regardless of the logical column type (date, numeric). The automatic `AdvancedFilterType` inference based on cell-value type then produces the wrong filter UI. `FilterPopupMenuOptions.advancedFilterType` lets the caller set the correct filter mode explicitly.

**Null/Not Null filter crash:**
Applying an "Is Null" / "Is Not Null" filter on a date or numeric column stores `null` as the condition value. On a subsequent data refresh or sort, `_debugCheckDataType` compared `null`'s runtime type against the column's expected type and threw a `FlutterError`, crashing the grid.

## Usage

### CheckboxFilterValueProvider

```dart
class MyDataSource extends DataGridSource with CheckboxFilterValueProvider {
  @override
  List<Object>? getCheckboxFilterValues(String columnName) {
    if (columnName == 'status') return <Object>['Active', 'Inactive'];
    return null; // fall back to default (row-derived) behaviour
  }
}
```

### advancedFilterType on FilterPopupMenuOptions

```dart
GridColumn(
  columnName: 'trx_date',
  filterPopupMenuOptions: const FilterPopupMenuOptions(
    advancedFilterType: AdvancedFilterType.date,
  ),
  label: const Text('Date'),
)
```

## Test plan

- [ ] Checkbox filter popup shows all custom values on any page of a server-side paginated grid.
- [ ] Returning `null` from `getCheckboxFilterValues` falls back to default row-derived values.
- [ ] Sources that do not use the mixin are unaffected.
- [ ] Selection state: values present in `effectiveRows` are checked when a filter is active; all values are checked when no filter is active.
- [ ] Selecting `equals` / `doesNotEqual` in the advanced filter popup shows a text input instead of a dropdown, and filtering by a typed value works.
- [ ] Other advanced filter types (begins with, ends with, contains, etc.) are unaffected.
- [ ] `advancedFilterType` on `FilterPopupMenuOptions` forces the popup to text/numeric/date mode.
- [ ] `AdvancedFilterType` is importable from the public package barrel.
- [ ] Applying "Is Null" / "Is Not Null" on a date column, then refreshing or sorting, does **not** throw a `FlutterError`.
- [ ] Existing default filter behaviour is unchanged.